### PR TITLE
Make panic semihosting a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "0.2.1"
-panic-semihosting = "0.5.2"
 cortex-m = "0.7"
 
 [dev-dependencies]
 cortex-m-rt = ">=0.6.15, <0.8"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 stm32f7xx-hal = {version = "0.6.0", features = ["stm32f746"]}
+panic-semihosting = "0.5.2"

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -13,6 +13,9 @@ use stm32f7xx_hal::{
     rcc::{HSEClock, HSEClockMode, Rcc},
 };
 
+#[allow(unused_imports)]
+use panic_semihosting;
+
 extern crate ft5336;
 
 /// A simple example to connect to the FT5336 crate and access it for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@
 #![deny(warnings)]
 #![no_std]
 
-#[allow(unused_imports)]
-use panic_semihosting;
-
 const FT5336_DEV_MODE_REG: u8 = 0x00;
 const FT5336_DEV_MODE_BIT_MASK: u8 = 0x70;
 const FT5336_DEV_MODE_BIT_POSITION: u8 = 4;


### PR DESCRIPTION
This should not be mandated by users of this crate (because they might
want to use a different panic handler), but the example needs it.